### PR TITLE
Add `bin_tree!` to create a new Node with less letters

### DIFF
--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -20,8 +20,50 @@ impl<T> BinaryTree<T> {
     }
 }
 
+#[macro_export]
+macro_rules! binary_tree_node {
+    (val: $val:expr, left: $left:expr, right: $right:expr,) => (
+        (
+            Box::new(BinaryTree::Node {
+                val: $val,
+                left: $left,
+                right: $right,
+            })
+        )
+    );
+
+    (val: $val:expr, right: $right:expr,) => (
+        (
+            binary_tree_node! {
+                val: $val,
+                left: Box::new(BinaryTree::Nil),
+                right: $right,
+            }
+        )
+    );
+
+    (val: $val:expr, left: $left:expr,) => (
+        (
+            binary_tree_node! {
+                val: $val,
+                left: $left,
+                right: Box::new(BinaryTree::Nil),
+            }
+        )
+    );
+
+    (val: $val: expr) => (
+        binary_tree_node!(
+            val: $val,
+            left: Box::new(BinaryTree::Nil),
+            right: Box::new(BinaryTree::Nil),
+        )
+    );
+}
+
+
 #[test]
-fn replace() {
+fn test_replace() {
     use BinaryTree::{Nil, Node};
 
     // tree1:
@@ -53,80 +95,44 @@ fn replace() {
     // tree1 は後ほどルートの右のNilを置き換えるので、 mut でつくる。
     let mut tree1 = BinaryTree::<i32>::Node {
         val: 5,
-        left: Box::new(BinaryTree::<i32>::Node {
+        left: binary_tree_node! {
             val: 4,
-            left: Box::new(BinaryTree::<i32>::Node {
+            left: binary_tree_node! {
                 val: 11,
-                left: Box::new(BinaryTree::<i32>::Node {
-                    val: 7,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-                right: Box::new(BinaryTree::<i32>::Node {
-                    val: 2,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-            }),
-            right: Box::new(Nil),
-        }),
+                left: binary_tree_node! { val: 7 },
+                right: binary_tree_node! { val: 2 },
+            },
+        },
         right: Box::new(Nil),
     };
 
     let tree2 = BinaryTree::<i32>::Node {
         val: 8,
-        left: Box::new(BinaryTree::<i32>::Node {
-            val: 13,
-            left: Box::new(Nil),
-            right: Box::new(Nil),
-        }),
-        right: Box::new(BinaryTree::<i32>::Node {
+        left: binary_tree_node! { val: 13 },
+        right: binary_tree_node! {
             val: 4,
-            left: Box::new(Nil),
-            right: Box::new(BinaryTree::<i32>::Node {
-                val: 1,
-                left: Box::new(Nil),
-                right: Box::new(Nil),
-            }),
-        }),
+            right: binary_tree_node! { val: 1 },
+        },
     };
 
     let tree3 = BinaryTree::<i32>::Node {
         val: 5,
-        left: Box::new(BinaryTree::<i32>::Node {
+        left: binary_tree_node! {
             val: 4,
-            left: Box::new(BinaryTree::<i32>::Node {
+            left: binary_tree_node! {
                 val: 11,
-                left: Box::new(BinaryTree::<i32>::Node {
-                    val: 7,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-                right: Box::new(BinaryTree::<i32>::Node {
-                    val: 2,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-            }),
-            right: Box::new(Nil),
-        }),
-        right: Box::new(BinaryTree::<i32>::Node {
+                left: binary_tree_node! { val: 7 },
+                right: binary_tree_node! { val: 2 },
+            },
+        },
+        right: binary_tree_node! {
             val: 8,
-            left: Box::new(BinaryTree::<i32>::Node {
-                val: 13,
-                left: Box::new(Nil),
-                right: Box::new(Nil),
-            }),
-            right: Box::new(BinaryTree::<i32>::Node {
+            left: binary_tree_node! { val: 13 },
+            right: binary_tree_node! {
                 val: 4,
-                left: Box::new(Nil),
-                right: Box::new(BinaryTree::<i32>::Node {
-                    val: 1,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-            }),
-        }),
+                right: binary_tree_node!{ val: 1 },
+            },
+        },
     };
 
     if let Node {

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -21,51 +21,42 @@ impl<T> BinaryTree<T> {
 }
 
 #[macro_export]
-macro_rules! binary_tree_node {
-    (val: $val:expr, left: $left:expr, right: $right:expr,) => (
-        (
-            Box::new(BinaryTree::Node {
-                val: $val,
-                left: $left,
-                right: $right,
-            })
-        )
-    );
-
-    (val: $val:expr, right: $right:expr,) => (
-        (
-            binary_tree_node! {
-                val: $val,
-                left: Box::new(BinaryTree::Nil),
-                right: $right,
-            }
-        )
-    );
-
-    (val: $val:expr, left: $left:expr,) => (
-        (
-            binary_tree_node! {
-                val: $val,
-                left: $left,
-                right: Box::new(BinaryTree::Nil),
-            }
-        )
-    );
-
-    (val: $val: expr) => (
-        binary_tree_node!(
+macro_rules! bin_tree {
+    (val: $val:expr, left: $left:expr, right: $right:expr,) => {
+        BinaryTree::Node {
             val: $val,
-            left: Box::new(BinaryTree::Nil),
-            right: Box::new(BinaryTree::Nil),
-        )
-    );
-}
+            left: Box::new($left),
+            right: Box::new($right),
+        }
+    };
 
+    (val: $val:expr, right: $right:expr,) => {
+        bin_tree! {
+            val: $val,
+            left: bin_tree!(),
+            right: $right,
+        }
+    };
+
+    (val: $val:expr, left: $left:expr,) => {
+        bin_tree! {
+            val: $val,
+            left: $left,
+            right: bin_tree!(),
+        }
+    };
+
+    (val: $val: expr) => {
+        bin_tree!(val: $val, left: bin_tree!(), right: bin_tree!(),)
+    };
+
+    () => {
+        BinaryTree::Nil
+    };
+}
 
 #[test]
 fn test_replace() {
-    use BinaryTree::{Nil, Node};
-
     // tree1:
     //       5
     //      /
@@ -93,49 +84,48 @@ fn test_replace() {
     //
 
     // tree1 は後ほどルートの右のNilを置き換えるので、 mut でつくる。
-    let mut tree1 = BinaryTree::<i32>::Node {
+    let mut tree1 = bin_tree! {
         val: 5,
-        left: binary_tree_node! {
+        left: bin_tree! {
             val: 4,
-            left: binary_tree_node! {
+            left: bin_tree! {
                 val: 11,
-                left: binary_tree_node! { val: 7 },
-                right: binary_tree_node! { val: 2 },
+                left: bin_tree! { val: 7 },
+                right: bin_tree! { val: 2 },
             },
         },
-        right: Box::new(Nil),
     };
 
-    let tree2 = BinaryTree::<i32>::Node {
+    let tree2 = bin_tree! {
         val: 8,
-        left: binary_tree_node! { val: 13 },
-        right: binary_tree_node! {
+        left: bin_tree! { val: 13 },
+        right: bin_tree! {
             val: 4,
-            right: binary_tree_node! { val: 1 },
+            right: bin_tree! { val: 1 },
         },
     };
 
-    let tree3 = BinaryTree::<i32>::Node {
+    let tree3 = bin_tree! {
         val: 5,
-        left: binary_tree_node! {
+        left: bin_tree! {
             val: 4,
-            left: binary_tree_node! {
+            left: bin_tree! {
                 val: 11,
-                left: binary_tree_node! { val: 7 },
-                right: binary_tree_node! { val: 2 },
+                left: bin_tree! { val: 7 },
+                right: bin_tree! { val: 2 },
             },
         },
-        right: binary_tree_node! {
+        right: bin_tree! {
             val: 8,
-            left: binary_tree_node! { val: 13 },
-            right: binary_tree_node! {
+            left: bin_tree! { val: 13 },
+            right: bin_tree! {
                 val: 4,
-                right: binary_tree_node!{ val: 1 },
+                right: bin_tree!{ val: 1 },
             },
         },
     };
 
-    if let Node {
+    if let BinaryTree::Node {
         val: _,
         left: _,
         right,

--- a/tests/binary_tree.rs
+++ b/tests/binary_tree.rs
@@ -1,4 +1,4 @@
-use data_structures_and_algorithms_rs::{BinaryTree,binary_tree_node};
+use data_structures_and_algorithms_rs::{bin_tree, BinaryTree};
 
 #[test]
 fn leetcode_112_path_sum_dfs() {
@@ -46,22 +46,22 @@ fn leetcode_112_path_sum_dfs() {
     //  /  \      \
     // 7    2      1
     //
-    let root = BinaryTree::<i32>::Node {
+    let root = bin_tree! {
         val: 5,
-        left: binary_tree_node! {
+        left: bin_tree! {
             val: 4,
-            left: binary_tree_node! {
+            left: bin_tree! {
                 val: 11,
-                left: binary_tree_node! { val: 7 },
-                right: binary_tree_node! { val: 2 },
+                left: bin_tree! { val: 7 },
+                right: bin_tree! { val: 2 },
             },
         },
-        right: binary_tree_node! {
+        right: bin_tree! {
             val: 8,
-            left: binary_tree_node! { val: 13 },
-            right: binary_tree_node! {
+            left: bin_tree! { val: 13 },
+            right: bin_tree! {
                 val: 4,
-                right: binary_tree_node! { val: 1 },
+                right: bin_tree! { val: 1 },
             },
         },
     };
@@ -119,22 +119,22 @@ fn leetcode_112_path_sum_bfs() {
         false // キューは空になったが、目指す総和のpathは見つからなかった
     }
 
-    let root = BinaryTree::<i32>::Node {
+    let root = bin_tree! {
         val: 5,
-        left: binary_tree_node! {
+        left: bin_tree! {
             val: 4,
-            left: binary_tree_node! {
+            left: bin_tree! {
                 val: 11,
-                left: binary_tree_node! { val: 7 },
-                right: binary_tree_node! { val: 2 },
+                left: bin_tree! { val: 7 },
+                right: bin_tree! { val: 2 },
             },
         },
-        right: binary_tree_node! {
+        right: bin_tree! {
             val: 8,
-            left: binary_tree_node! { val: 13 },
-            right: binary_tree_node! {
+            left: bin_tree! { val: 13 },
+            right: bin_tree! {
                 val: 4,
-                right: binary_tree_node! { val: 1 },
+                right: bin_tree! { val: 1 },
             },
         },
     };

--- a/tests/binary_tree.rs
+++ b/tests/binary_tree.rs
@@ -1,4 +1,4 @@
-use data_structures_and_algorithms_rs::BinaryTree;
+use data_structures_and_algorithms_rs::{BinaryTree,binary_tree_node};
 
 #[test]
 fn leetcode_112_path_sum_dfs() {
@@ -48,40 +48,22 @@ fn leetcode_112_path_sum_dfs() {
     //
     let root = BinaryTree::<i32>::Node {
         val: 5,
-        left: Box::new(BinaryTree::<i32>::Node {
+        left: binary_tree_node! {
             val: 4,
-            left: Box::new(BinaryTree::<i32>::Node {
+            left: binary_tree_node! {
                 val: 11,
-                left: Box::new(BinaryTree::<i32>::Node {
-                    val: 7,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-                right: Box::new(BinaryTree::<i32>::Node {
-                    val: 2,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-            }),
-            right: Box::new(Nil),
-        }),
-        right: Box::new(BinaryTree::<i32>::Node {
+                left: binary_tree_node! { val: 7 },
+                right: binary_tree_node! { val: 2 },
+            },
+        },
+        right: binary_tree_node! {
             val: 8,
-            left: Box::new(BinaryTree::<i32>::Node {
-                val: 13,
-                left: Box::new(Nil),
-                right: Box::new(Nil),
-            }),
-            right: Box::new(BinaryTree::<i32>::Node {
+            left: binary_tree_node! { val: 13 },
+            right: binary_tree_node! {
                 val: 4,
-                left: Box::new(Nil),
-                right: Box::new(BinaryTree::<i32>::Node {
-                    val: 1,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-            }),
-        }),
+                right: binary_tree_node! { val: 1 },
+            },
+        },
     };
 
     // 総和が22になるpathは存在する。
@@ -139,40 +121,22 @@ fn leetcode_112_path_sum_bfs() {
 
     let root = BinaryTree::<i32>::Node {
         val: 5,
-        left: Box::new(BinaryTree::<i32>::Node {
+        left: binary_tree_node! {
             val: 4,
-            left: Box::new(BinaryTree::<i32>::Node {
+            left: binary_tree_node! {
                 val: 11,
-                left: Box::new(BinaryTree::<i32>::Node {
-                    val: 7,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-                right: Box::new(BinaryTree::<i32>::Node {
-                    val: 2,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-            }),
-            right: Box::new(Nil),
-        }),
-        right: Box::new(BinaryTree::<i32>::Node {
+                left: binary_tree_node! { val: 7 },
+                right: binary_tree_node! { val: 2 },
+            },
+        },
+        right: binary_tree_node! {
             val: 8,
-            left: Box::new(BinaryTree::<i32>::Node {
-                val: 13,
-                left: Box::new(Nil),
-                right: Box::new(Nil),
-            }),
-            right: Box::new(BinaryTree::<i32>::Node {
+            left: binary_tree_node! { val: 13 },
+            right: binary_tree_node! {
                 val: 4,
-                left: Box::new(Nil),
-                right: Box::new(BinaryTree::<i32>::Node {
-                    val: 1,
-                    left: Box::new(Nil),
-                    right: Box::new(Nil),
-                }),
-            }),
-        }),
+                right: binary_tree_node! { val: 1 },
+            },
+        },
     };
     assert_eq!(has_path_sum(&root, 22), true);
 }


### PR DESCRIPTION
Thank you for the awesome examples and blog entries. I am learning Rust with them.

However, `Box::new(BinaryTree::Node { ... })` makes the code to be hard to read for me, so this PR adds a macro as a shortcut of `Box::new(BinaryTree::Node { ... })` with less typings.

What do you think of it?